### PR TITLE
Use api-skeletons/oauth2-doctrine with version 5 that supports PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
     fi
 
 after_script:
-  - php ./vendor/bin/coveralls -v
+  - php ./vendor/bin/php-coveralls -v
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.3 || ~8.0",
         "laminas/laminas-modulemanager": "^2.10.1",
         "laminas/laminas-stdlib": "^2.7 || ^3.0",
-        "samsonasik/zf-oauth2-doctrine": "^4.0"
+        "api-skeletons/oauth2-doctrine": "^4.0 || ^5.1"
     },
     "autoload": {
         "psr-4": {
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2",
-        "squizlabs/php_codesniffer": "^2.7",
-        "satooshi/php-coveralls": "~1.0"
+        "squizlabs/php_codesniffer": "^2.7 || ^3.6",
+        "php-coveralls/php-coveralls": "^2.5"
     }
 }

--- a/tests/src/Container/MutateTableNamesSubscriberFactoryTest.php
+++ b/tests/src/Container/MutateTableNamesSubscriberFactoryTest.php
@@ -16,7 +16,7 @@ class MutateTableNamesSubscriberFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
 
-        $container->expects($this->at(0))
+        $container->expects($this->once())
             ->method('get')
             ->with('config')
             ->willReturn([
@@ -40,7 +40,7 @@ class MutateTableNamesSubscriberFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $container = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
 
-        $container->expects($this->at(0))
+        $container->expects($this->once())
             ->method('get')
             ->with('config')
             ->willReturn([
@@ -64,7 +64,7 @@ class MutateTableNamesSubscriberFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
 
-        $container->expects($this->at(0))
+        $container->expects($this->once())
             ->method('get')
             ->with('config')
             ->willReturn([

--- a/tests/src/ModuleTest.php
+++ b/tests/src/ModuleTest.php
@@ -37,28 +37,18 @@ class ModuleTest extends \PHPUnit\Framework\TestCase
         $application->expects($this->once())->method('getServiceManager')->willReturn($serviceLocator);
 
         // get config from service manager mock
-        $serviceLocator->expects($this->at(0))
+        // get subscriber from service manager mock
+        // get doctrine event manager mock from service locatior
+        $serviceLocator->expects($this->exactly(3))
             ->method('get')
-            ->with('config')
-            ->willReturn([
+            ->withConsecutive(['config'], [MutateTableNamesSubscriber::class], ['event_manager_service_name'])
+            ->willReturnOnConsecutiveCalls([
                 'zf-oauth2-doctrine' => [
                     'default' => [
                         'event_manager' => 'event_manager_service_name'
                     ]
                 ]
-            ]);
-
-        // get subscriber from service manager mock
-        $serviceLocator->expects($this->at(1))
-            ->method('get')
-            ->with(MutateTableNamesSubscriber::class)
-            ->willReturn($mutateTableNamesSubscriber);
-
-        // get doctrine event manager mock from service locatior
-        $serviceLocator->expects($this->at(2))
-            ->method('get')
-            ->with('event_manager_service_name')
-            ->willReturn($eventManager);
+            ], $mutateTableNamesSubscriber, $eventManager);
 
         // add subscriber to doctrine event manager
         $eventManager->expects($this->once())


### PR DESCRIPTION
Hi there,

Currently it is not possible tu use this on PHP8, here is a merge request that hopefully will solve that. Please let me know if I need to change anything

Dependency update:
 - api-skeletons/oauth2-doctrine version 4 for PHP ^7.3 and version 5 for PHP 8
 - satooshi/php-coveralls is archived so replaced with php-coveralls/php-coveralls

Remove deprecated at() method from phpunit